### PR TITLE
Fix popup IndexedDB initialization

### DIFF
--- a/react-ts/popup.tsx
+++ b/react-ts/popup.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react"
-import { openDB } from "idb"
+import { dbPromise } from "./lib/db"
 
 export const HistoryPanel = () => {
   const [items, setItems] = useState<
@@ -8,7 +8,7 @@ export const HistoryPanel = () => {
 
   useEffect(() => {
     ;(async () => {
-      const db = await openDB("clipboard-db", 1)
+      const db = await dbPromise
       const tx = db.transaction("items", "readonly")
       const all = await tx.store.getAll()
       setItems(all.reverse()) // 新しい順


### PR DESCRIPTION
## Summary
- use shared `dbPromise` when reading clipboard history so that the `items` store is created on first run

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687c6749f19883238e4acfef4934c5aa